### PR TITLE
IntensityProcessorの震度計算バグを修正

### DIFF
--- a/include/IntensityProcessor.h
+++ b/include/IntensityProcessor.h
@@ -95,6 +95,9 @@ public:
             float max = 0;
             int maxIndex = 0;
             for (auto g = 0; g < PROCESS_SAMPLE_GROUP_COUNT; g++) {
+                // 使い切ったグループを選ぶと添字が負になり、隣の値を二重に数えてしまう
+                if (sortedGroupIndice[g] >= INTENSITY_PROCESS_SAMPLE_GROUP_SIZE)
+                    continue;
                 auto v = sortedGroups[g][INTENSITY_PROCESS_SAMPLE_GROUP_SIZE - (sortedGroupIndice[g] + 1)];
                 if (!isnan(v) && max < v) {
                     max = v;

--- a/include/IntensityProcessor.h
+++ b/include/IntensityProcessor.h
@@ -21,7 +21,7 @@ class IntensityProcessor {
 
     // float hpFilteredSample[INTENSITY_PROCESS_SAMPLE_GROUP_SIZE];
     float compositeSample[INTENSITY_PROCESS_SAMPLE_GROUP_SIZE];
-    float sortedGroups[PROCESS_SAMPLE_GROUP_COUNT][INTENSITY_PROCESS_SAMPLE_GROUP_SIZE];
+    float sortedGroups[PROCESS_SAMPLE_GROUP_COUNT][INTENSITY_PROCESS_SAMPLE_GROUP_SIZE] = {};
     char sortedGroupIndice[PROCESS_SAMPLE_GROUP_COUNT];
     
     ushort sampleIndex = 0;
@@ -29,7 +29,7 @@ class IntensityProcessor {
 
     IntensityFilter filter;
 
-    float rawIntHistory[PROCESS_SAMPLE_GROUP_COUNT];
+    float rawIntHistory[PROCESS_SAMPLE_GROUP_COUNT] = {};
     unsigned int rawIntIndex = 0;
     unsigned int stabilityCheckCount = 0;
     bool isStable = false;

--- a/include/IntensityProcessor.h
+++ b/include/IntensityProcessor.h
@@ -96,7 +96,7 @@ public:
             int maxIndex = 0;
             for (auto g = 0; g < PROCESS_SAMPLE_GROUP_COUNT; g++) {
                 auto v = sortedGroups[g][INTENSITY_PROCESS_SAMPLE_GROUP_SIZE - (sortedGroupIndice[g] + 1)];
-                if (v != NAN && max < v) {
+                if (!isnan(v) && max < v) {
                     max = v;
                     maxIndex = g;
                 }


### PR DESCRIPTION
## 概要

`include/IntensityProcessor.h` の上位30値抽出処理のバグ修正

## 修正内容

### NaN チェックが機能していない

`v != NAN` は NaN がどの値とも比較不等になるため常に true で、ガードとして働いていない。`isnan()` に置き換える。

### グループ枯渇時の範囲外読み

`INTENSITY_PROCESS_SAMPLE_GROUP_SIZE` は各 `Board.h` で 20 に上書きされており、1グループ20サンプルに対して上位30値を取り出すループが回る。ひとつのグループを20回選んで使い切った後、21回目の読み出しで添字が `20 - (20 + 1) = -1` になる。昇順ソート済みのため `sortedGroups[g][-1]` は隣グループの最大値を指し、同じ値を二重に数える。

発生条件は2つ

- 起動直後。実データを持つのがグループ0のみで他は0のため `max < v` が成立せず、グループ0が選ばれ続けて21回目で範囲外に出る
- 強い揺れのとき、0.2秒ぶんのグループひとつに上位30値のうち21個以上が集中した場合

### バッファが未初期化

`processor = new IntensityProcessor(...)` とヒープに確保しているため、暗黙のゼロ初期化が働かない。`sortedGroups` は 300 × 20 の float で、起動直後から未初期化ヒープを読んでいた。`= {}` を追加する。

`compositeSample` と `sortedGroupIndice` は使用前に全要素の書き込みと `memset` があるため変更なし。

## 挙動の変化

2番目の修正により、起動から数秒は30番目の値が揃わず `lastMaxValue` が0になり、震度出力がスキップされる(従来はゴミ値を出力していた)。`stabilityCheckCount` の加算も同じ分岐のため、安定判定の開始がそのぶん遅れる。

## 動作確認

5環境すべてビルド確認済。

RP2040 の3環境はクリーンな状態だと本件と無関係な理由でビルドが通らない。`lib_deps` の `FreeRTOS` が名前衝突で feilipu の AVR ATmega 向け Arduino_FreeRTOS_Library に解決されること、および現在の framework-arduinopico が `-D __FREERTOS=1` を要求することによる。確認時は `lib_deps` から `FreeRTOS` を外し `-D __FREERTOS=1` を追加した。別件のため `platformio.ini` は変更していない。
